### PR TITLE
remove erroneous space character from url

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Combines the power of redux middleware and @gaearon's
 relational, nested data a snap.
 
 Use with [redux-thunk](https://github.com/gaearon/redux-thunk) or
-[redux-promise-middleware](https://github.com/pburtchaell/redux-promise- middleware)
+[redux-promise-middleware](https://github.com/pburtchaell/redux-promise-middleware)
 to easily request and store your API's response in a database-like fashion in your redux apps!
 
 For an example of a more manual implementation, check out [the


### PR DESCRIPTION
Noticed a link in the README was broken when clicking it on Github, so I fixed it. 1 character change.
