### PR TITLE
Update for normalizr 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,12 @@
     "babel-cli": "^6.4.5",
     "babel-preset-es2015": "^6.3.13",
     "faucet": "0.0.1",
+    "normalizr": "^3.0.0",
     "redux": "^3.0.5",
     "tap": "^5.1.1"
   },
   "dependencies": {
-    "normalizr": "^2.0.0",
+    "normalizr": "^2.0.0 || ^3.0.0",
     "lodash": "^4.0.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 import tap, { test } from 'tap';
 import { createStore, applyMiddleware } from 'redux';
-import { Schema, arrayOf } from 'normalizr';
+import { schema } from 'normalizr';
 
 import normalizrMiddleware from './index';
 
@@ -9,21 +9,21 @@ function mergeReducer(state = {}, action) {
 }
 
 // from the normalizr readme
-const article = new Schema('articles');
-const user = new Schema('users');
-const collection = new Schema('collections');
+const article = new schema.Entity('articles');
+const user = new schema.Entity('users');
+const collection = new schema.Entity('collections');
 
 article.define({
   author: user,
-  collections: arrayOf(collection)
+  collections: [collection]
 });
 
 collection.define({
   curator: user
 });
 
-const schema = {
-  articles: arrayOf(article)
+const articlesSchema = {
+  articles: [article]
 };
 
 const response = {
@@ -83,7 +83,7 @@ test('normalizes payload with FSA defaults', t => {
     type: 'FOO',
     payload: response,
     meta: {
-      schema
+      schema: articlesSchema
     }
   })
 
@@ -96,7 +96,7 @@ test('action is unmodified before middleware', t => {
     type: 'FOO',
     payload: response,
     meta: {
-      schema
+      schema: articlesSchema
     }
   };
 
@@ -120,7 +120,7 @@ test('preserves other action properties when normalizing', t => {
     type: 'FOO',
     payload: response,
     meta: {
-      schema,
+      schema: articlesSchema,
       some: 'other',
       meta: 'data'
     }


### PR DESCRIPTION
normalizr 3.x has been released.  The `normalize` API used by this middleware continues to work unchanged, so I modified the dependency spec to be `^2.0.0 || ^3.0.0`.

However, the `Schema` API has completely changed in 3.x, which causes problems with the tests.  I updated the tests to use the new 3.x API and added a dev dependency on `^3.0.0` to ensure that the correct version gets installed when developing.

The problem with this approach is that there isn’t really a way to continue to run the tests against 2.x to make sure nothing breaks in the future.

I’m happy to pursue a different direction if you’d like.  Perhaps it’s best to release a v3.0.0 of this library that depends on normalizr 3.x; people still on normalizr 2 can continue to use v2.x of this library.